### PR TITLE
pydensecrf2 for pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
-PyDenseCRF
+PyDenseCRF2
 ==========
+
+NOTE: this code is forked from `https://github.com/lucasb-eyer/pydensecrf`, which is not actively maintained. However, this is a highly useful dependency for our work, [CellSeg3D](https://github.com/AdaptiveMotorControlLab/CellSeg3), thus we am maintaing the package for `pypi` here!
+
+
+Quick start:
+
+```
+pip install pydensecrf2
+import pydensecrf
+```
+
+### Original Readme:
+----------
 
 This is a (Cython-based) Python wrapper for [Philipp Krähenbühl's Fully-Connected CRFs](http://web.archive.org/web/20161023180357/http://www.philkr.net/home/densecrf) (version 2, [new, incomplete page](http://www.philkr.net/2011/12/01/nips/)).
 

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,15 @@ except ImportError:
     ]
 
 setup(
-    name="pydensecrf",
+    name="pydensecrf2",
     version="1.0",
     description="A python interface to Philipp Krähenbühl's fully-connected (dense) CRF code.",
     long_description="See the README.md at http://github.com/lucasb-eyer/pydensecrf",
-    author="Lucas Beyer",
+    author="Lucas Beyer, Philipp Krähenbühl",
     author_email="lucasb.eyer.be@gmail.com",
-    url="http://github.com/lucasb-eyer/pydensecrf",
+    maintainer="Mackenzie Mathis",  
+    maintainer_email="mackenzie@post.harvard.edu", 
+    url="https://github.com/adaptivemotorcontrollab/pydensecrf",
     ext_modules=ext_modules,
     packages=["pydensecrf"],
     setup_requires=['cython==0.29.36'],


### PR DESCRIPTION
- Because pydensecrf is not actively maintained on pypi (last release is 2018) and broken, we have forked [the repo](https://github.com/lucasb-eyer/pydensecrf) and maintain it here. 
- You can install it now with `pydensecrf2` yet it keeps the import as `pydensecrf`; namely, you can use this package without renaming any imports into your code! 