### PR TITLE
Add Github actions to build wheels

### DIFF
--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64
+        CIBW_BUILD: cp3*-win_amd64
     - name: Upload wheels to GitHub Release
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -28,9 +28,3 @@ jobs:
         files: wheelhouse/*.whl
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Upload wheels to GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: wheelhouse/*.whl
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -13,23 +13,18 @@ on:
 jobs:
   build_wheels:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install build dependencies
-      run: pip install build
+        python-version: '3.11'
     - name: Build wheels with cibuildwheel
       uses: pypa/cibuildwheel@v2.23.3
       with:
         output-dir: wheelhouse
       env:
-        CIBW_PLATFORM: windows
+        CIBW_BUILD: cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp3*-win_amd64
+        CIBW_BUILD: cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64
     - name: Upload wheels to GitHub Release
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -25,8 +25,25 @@ jobs:
         output-dir: wheelhouse
       env:
         CIBW_BUILD: cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64
-    - name: Upload wheels
+    - name: Upload wheels for each Python version
+      run: |
+        for whl in wheelhouse/*.whl
+        set whl_name (basename $whl)
+        echo "Uploading $whl_name"
+        gh release upload temp-release $whl --clobber || true
+        echo "::group::Upload $whl_name"
+        echo "::endgroup::"
+      shell: bash
+    - name: Upload wheels as separate artifacts
+      run: |
+        for whl in wheelhouse/*.whl; do
+          whl_name=$(basename "$whl" .whl)
+          echo "Uploading $whl as $whl_name"
+          mkdir -p artifacts/$whl_name
+          cp "$whl" artifacts/$whl_name/
+        done
+      shell: bash
+    - name: Upload all wheel artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: wheels
-        path: wheelhouse/*.whl
+        path: artifacts/*/*.whl

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -27,6 +27,7 @@ jobs:
         CIBW_BUILD: cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64
     - name: Get version from git tag
       id: get_version
+      shell: bash
       run: |
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           VERSION=${GITHUB_REF#refs/tags/}

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -4,11 +4,8 @@
 name: Build wheels (Windows)
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
+  release:
+    types: [ published ]
 
 jobs:
   build_wheels:
@@ -25,24 +22,10 @@ jobs:
         output-dir: wheelhouse
       env:
         CIBW_BUILD: cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64
-    - name: Get version from git tag
-      id: get_version
-      shell: bash
-      run: |
-        if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-          VERSION=${GITHUB_REF#refs/tags/}
-        else
-          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "latest-$(git rev-parse --short HEAD)")
-        fi
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-    - name: Create GitHub Release
-      if: github.ref_type == 'tag' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    - name: Upload wheels to GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ github.ref_type == 'tag' && github.ref_name || steps.get_version.outputs.version }}
-        name: Release ${{ github.ref_type == 'tag' && github.ref_name || steps.get_version.outputs.version }}
-        draft: false
-        prerelease: ${{ github.ref_type != 'tag' }}
+        files: wheelhouse/*.whl
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload wheels to GitHub Release

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -6,9 +6,9 @@ name: Build wheels (Windows)
 on:
   workflow_dispatch:
   push:
-    branches: [ main, master, test_ga_build ]
+    branches: [ main, master ]
   pull_request:
-    branches: [ main, master, test_ga_build ]
+    branches: [ main, master ]
 
 jobs:
   build_wheels:
@@ -25,25 +25,28 @@ jobs:
         output-dir: wheelhouse
       env:
         CIBW_BUILD: cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64
-    - name: Upload wheels for each Python version
+    - name: Get version from git tag
+      id: get_version
       run: |
-        for whl in wheelhouse/*.whl
-        set whl_name (basename $whl)
-        echo "Uploading $whl_name"
-        gh release upload temp-release $whl --clobber || true
-        echo "::group::Upload $whl_name"
-        echo "::endgroup::"
-      shell: bash
-    - name: Upload wheels as separate artifacts
-      run: |
-        for whl in wheelhouse/*.whl; do
-          whl_name=$(basename "$whl" .whl)
-          echo "Uploading $whl as $whl_name"
-          mkdir -p artifacts/$whl_name
-          cp "$whl" artifacts/$whl_name/
-        done
-      shell: bash
-    - name: Upload all wheel artifacts
-      uses: actions/upload-artifact@v4
+        if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+          VERSION=${GITHUB_REF#refs/tags/}
+        else
+          VERSION=$(git describe --tags --abbrev=0)
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+    - name: Create GitHub Release
+      if: github.ref_type == 'tag' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+      uses: softprops/action-gh-release@v2
       with:
-        path: artifacts/*/*.whl
+        tag_name: ${{ steps.get_version.outputs.version }}
+        name: Release ${{ steps.get_version.outputs.version }}
+        draft: false
+        prerelease: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload wheels to GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: wheelhouse/*.whl
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -15,19 +15,21 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install cibuildwheel
-      run: pip install cibuildwheel
-    - name: Build wheels
-      run: cibuildwheel --platform windows
+    - name: Install build dependencies
+      run: pip install build
+    - name: Build wheels with cibuildwheel
+      uses: pypa/cibuildwheel@v2.23.3
+      with:
+        output-dir: wheelhouse
       env:
-        CIBW_BUILD: cp3*-win_amd64
+        CIBW_PLATFORM: windows
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -1,0 +1,35 @@
+# This workflow builds Python wheels for Windows using cibuildwheel
+# See: https://cibuildwheel.readthedocs.io/en/stable/
+
+name: Build wheels (Windows)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build_wheels:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install cibuildwheel
+      run: pip install cibuildwheel
+    - name: Build wheels
+      run: cibuildwheel --platform windows
+      env:
+        CIBW_BUILD: cp3*-win_amd64
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels
+        path: wheelhouse/*.whl

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -6,9 +6,9 @@ name: Build wheels (Windows)
 on:
   workflow_dispatch:
   push:
-    branches: [ main, master ]
+    branches: [ main, master, test_ga_build ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main, master, test_ga_build ]
 
 jobs:
   build_wheels:

--- a/.github/workflows/build-wheels-windows.yml
+++ b/.github/workflows/build-wheels-windows.yml
@@ -32,17 +32,17 @@ jobs:
         if [ "$GITHUB_REF_TYPE" = "tag" ]; then
           VERSION=${GITHUB_REF#refs/tags/}
         else
-          VERSION=$(git describe --tags --abbrev=0)
+          VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "latest-$(git rev-parse --short HEAD)")
         fi
         echo "version=$VERSION" >> $GITHUB_OUTPUT
     - name: Create GitHub Release
       if: github.ref_type == 'tag' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: ${{ steps.get_version.outputs.version }}
-        name: Release ${{ steps.get_version.outputs.version }}
+        tag_name: ${{ github.ref_type == 'tag' && github.ref_name || steps.get_version.outputs.version }}
+        name: Release ${{ github.ref_type == 'tag' && github.ref_name || steps.get_version.outputs.version }}
         draft: false
-        prerelease: false
+        prerelease: ${{ github.ref_type != 'tag' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload wheels to GitHub Release


### PR DESCRIPTION
I couldn't install `napari-cellseg3d` on Windows as it was needing some Visual C++ installed. 

I added the wheels to be uploaded back to the releases, so that it might get pushed to conda-forge (as was the original) but I don't know how to make that, and it's probably best if you are in charge ! :) 